### PR TITLE
Save flow metadata fix

### DIFF
--- a/Govt-Billing-React/src/components/Menu/Menu.tsx
+++ b/Govt-Billing-React/src/components/Menu/Menu.tsx
@@ -48,14 +48,6 @@ const Menu: React.FC<{
     return props.file;
   };
 
-  const _formatString = (filename) => {
-    /* Remove whitespaces */
-    while (filename.indexOf(" ") !== -1) {
-      filename = filename.replace(" ", "");
-    }
-    return filename;
-  };
-
   const doPrint = () => {
     if (isPlatform("hybrid")) {
       const printer = Printer;
@@ -68,23 +60,33 @@ const Menu: React.FC<{
       printWindow.print();
     }
   };
-  const doSave = () => {
+  const doSave = async () => {
     if (props.file === "default") {
       setShowAlert1(true);
       return;
     }
-    const content = encodeURIComponent(AppGeneral.getSpreadsheetContent());
-    const data = props.store._getFile(props.file);
-    const file = new File(
-      (data as any).created,
-      new Date().toString(),
-      content,
-      props.file,
-      props.bT
-    );
-    props.store._saveFile(file);
-    props.updateSelectedFile(props.file);
-    setShowAlert2(true);
+    try {
+      const content = encodeURIComponent(AppGeneral.getSpreadsheetContent());
+      const data = await props.store._getFile(props.file);
+      if (!data) {
+        setToastMessage("Unable to load saved metadata for this file.");
+        setShowToast1(true);
+        return;
+      }
+      const file = new File(
+        (data as any).created,
+        new Date().toString(),
+        content,
+        props.file,
+        props.bT
+      );
+      await props.store._saveFile(file);
+      props.updateSelectedFile(props.file);
+      setShowAlert2(true);
+    } catch {
+      setToastMessage("Unable to save file. Please try again.");
+      setShowToast1(true);
+    }
   };
 
   const doSaveAs = async (filename) => {
@@ -104,7 +106,7 @@ const Menu: React.FC<{
         );
         // const data = { created: file.created, modified: file.modified, content: file.content, password: file.password };
         // console.log(JSON.stringify(data));
-        props.store._saveFile(file);
+        await props.store._saveFile(file);
         props.updateSelectedFile(filename);
         setShowAlert4(true);
       } else {

--- a/Govt-Billing-React/src/components/NewFile/NewFile.tsx
+++ b/Govt-Billing-React/src/components/NewFile/NewFile.tsx
@@ -12,19 +12,27 @@ const NewFile: React.FC<{
   billType: number;
 }> = (props) => {
   const [showAlertNewFileCreated, setShowAlertNewFileCreated] = useState(false);
-  const newFile = () => {
+  const newFile = async () => {
     if (props.file !== "default") {
-      const content = encodeURIComponent(AppGeneral.getSpreadsheetContent());
-      const data = props.store._getFile(props.file);
-      const file = new File(
-        (data as any).created,
-        new Date().toString(),
-        content,
-        props.file,
-        props.billType
-      );
-      props.store._saveFile(file);
-      props.updateSelectedFile(props.file);
+      try {
+        const content = encodeURIComponent(AppGeneral.getSpreadsheetContent());
+        const data = await props.store._getFile(props.file);
+        if (data) {
+          const file = new File(
+            (data as any).created,
+            new Date().toString(),
+            content,
+            props.file,
+            props.billType
+          );
+          await props.store._saveFile(file);
+          props.updateSelectedFile(props.file);
+        } else {
+          alert("Current file metadata was not found. Changes were not saved.");
+        }
+      } catch {
+        alert("Unable to save current file before creating a new one.");
+      }
     }
     const msc = DATA["home"][AppGeneral.getDeviceType()]["msc"];
     AppGeneral.viewFile("default", JSON.stringify(msc));
@@ -40,7 +48,7 @@ const NewFile: React.FC<{
         className="ion-padding-end"
         size="large"
         onClick={() => {
-          newFile();
+          void newFile();
           // console.log("New file clicked");
         }}
       />

--- a/Govt-Billing-React/src/components/Storage/LocalStorage.ts
+++ b/Govt-Billing-React/src/components/Storage/LocalStorage.ts
@@ -39,7 +39,14 @@ export class Local {
 
   _getFile = async (name: string) => {
     const rawData = await Preferences.get({ key: name });
-    return JSON.parse(rawData.value);
+    if (!rawData.value) {
+      return null;
+    }
+    try {
+      return JSON.parse(rawData.value);
+    } catch {
+      return null;
+    }
   };
 
   _getAllFiles = async () => {
@@ -48,7 +55,9 @@ export class Local {
     for (let i = 0; i < keys.length; i++) {
       let fname = keys[i];
       const data = await this._getFile(fname);
-      arr[fname] = (data as any).modified;
+      if (data) {
+        arr[fname] = (data as any).modified;
+      }
     }
     return arr;
   };


### PR DESCRIPTION
## Summary
Refers to #38 
This PR fixes local persistence reliability in the Ionic React app by making save flows async-safe and null-safe.

## Changes
- `Govt-Billing-React/src/components/Menu/Menu.tsx`
  - Made `doSave` async and awaited `_getFile(...)`.
  - Preserved `created` timestamp and updated `modified`.
  - Added safe fallback toast on missing metadata/save failure.
  - Awaited `_saveFile(...)` in `doSaveAs`.
- `Govt-Billing-React/src/components/NewFile/NewFile.tsx`
  - Made `newFile` async and awaited `_getFile(...)`.
  - Added guard alerts for missing metadata/save failure.
- `Govt-Billing-React/src/components/Storage/LocalStorage.ts`
  - Made `_getFile` null-safe for missing/invalid JSON.
  - Updated `_getAllFiles` to skip invalid entries.

## Why
Previously, `_getFile(...)` promises were used like resolved objects in save flows, which could break metadata handling and lead to inconsistent file persistence.

## Flow Diagram
```mermaid
flowchart TD
  subgraph Before
    A1[Save/New File] --> B1[_getFile returns Promise]
    B1 --> C1[Read data.created immediately]
    C1 --> D1[Invalid metadata may be written]
  end

  subgraph After
    A2[Save/New File] --> B2[await _getFile]
    B2 --> C2{Data valid?}
    C2 -- Yes --> D2[Preserve created, update modified]
    D2 --> E2[await _saveFile]
    C2 -- No --> F2[Show alert/toast and stop safely]
  end
