### PR TITLE
Await file loads in new file flow

### DIFF
--- a/Govt-Billing-React-Ad-Subscriptions/src/components/NewFile/NewFile.tsx
+++ b/Govt-Billing-React-Ad-Subscriptions/src/components/NewFile/NewFile.tsx
@@ -12,10 +12,10 @@ const NewFile: React.FC<{
   billType: number;
 }> = (props) => {
   const [showAlertNewFileCreated, setShowAlertNewFileCreated] = useState(false);
-  const newFile = () => {
+  const newFile = async () => {
     if (props.file !== "default") {
       const content = encodeURIComponent(AppGeneral.getSpreadsheetContent());
-      const data = props.store._getFile(props.file);
+      const data = await props.store._getFile(props.file);
       const file = new File(
         (data as any).created,
         new Date().toString(),
@@ -23,7 +23,7 @@ const NewFile: React.FC<{
         props.file,
         props.billType
       );
-      props.store._saveFile(file);
+      await props.store._saveFile(file);
       props.updateSelectedFile(props.file);
     }
     const msc = DATA["home"][AppGeneral.getDeviceType()]["msc"];
@@ -40,7 +40,7 @@ const NewFile: React.FC<{
         className="ion-padding-end"
         size="large"
         onClick={() => {
-          newFile();
+          void newFile();
           // console.log("New file clicked");
         }}
       />

--- a/Govt-Billing-React/src/components/NewFile/NewFile.tsx
+++ b/Govt-Billing-React/src/components/NewFile/NewFile.tsx
@@ -12,10 +12,10 @@ const NewFile: React.FC<{
   billType: number;
 }> = (props) => {
   const [showAlertNewFileCreated, setShowAlertNewFileCreated] = useState(false);
-  const newFile = () => {
+  const newFile = async () => {
     if (props.file !== "default") {
       const content = encodeURIComponent(AppGeneral.getSpreadsheetContent());
-      const data = props.store._getFile(props.file);
+      const data = await props.store._getFile(props.file);
       const file = new File(
         (data as any).created,
         new Date().toString(),
@@ -23,7 +23,7 @@ const NewFile: React.FC<{
         props.file,
         props.billType
       );
-      props.store._saveFile(file);
+      await props.store._saveFile(file);
       props.updateSelectedFile(props.file);
     }
     const msc = DATA["home"][AppGeneral.getDeviceType()]["msc"];
@@ -40,7 +40,7 @@ const NewFile: React.FC<{
         className="ion-padding-end"
         size="large"
         onClick={() => {
-          newFile();
+          void newFile();
           // console.log("New file clicked");
         }}
       />


### PR DESCRIPTION
## Summary
- await `_getFile()` before reading the existing file metadata in the New File flow
- await `_saveFile()` so the updated file is persisted before switching selected files
- apply the same fix in both React app variants that contain the duplicated NewFile component

## Verification
- issue #42 is currently unassigned and has no closing PR references
- inspected both NewFile components and confirmed `_getFile` is async in `LocalStorage.ts`
- verified branch diff contains only the two intended `NewFile.tsx` files

Fixes #42