### PR TITLE
fix: correct PWA manifest branding and VitePWA config

### DIFF
--- a/Govt-Billing-React/public/manifest.json
+++ b/Govt-Billing-React/public/manifest.json
@@ -1,6 +1,7 @@
 {
-  "short_name": "Ionic App",
-  "name": "My Ionic App",
+  "short_name": "GovtInvoice",
+  "name": "Government Invoice & Billing System",
+  "description": "Cross-platform invoicing and billing system for government institutions and educational bodies.",
   "icons": [
     {
       "src": "pwa-64x64.png",
@@ -25,8 +26,11 @@
       "purpose": "maskable"
     }
   ],
-  "start_url": ".",
+  "start_url": "/",
+  "scope": "/",
   "display": "standalone",
-  "theme_color": "#ffffff",
-  "background_color": "#ffffff"
+  "orientation": "portrait",
+  "theme_color": "#3880ff",
+  "background_color": "#ffffff",
+  "categories": ["finance", "productivity", "utilities"]
 }

--- a/Govt-Billing-React/src/app-data.ts
+++ b/Govt-Billing-React/src/app-data.ts
@@ -1,4 +1,4 @@
-export let APP_NAME = "Inventory Tracker for FVM Warehouse";
+export let APP_NAME = "Government Invoice & Billing System";
 
 export let DATA = {
   ledger: {

--- a/Govt-Billing-React/vite.config.ts
+++ b/Govt-Billing-React/vite.config.ts
@@ -10,6 +10,39 @@ export default defineConfig({
     react(),
     legacy(),
     commonjs(),
-    VitePWA({ registerType: "autoUpdate" }),
+    VitePWA({
+      registerType: "autoUpdate",
+      includeAssets: ["favicon.ico", "apple-touch-icon-180x180.png", "pwa-*.png"],
+      manifest: {
+        name: "Government Invoice & Billing System",
+        short_name: "GovtInvoice",
+        description: "Cross-platform invoicing and billing system for government institutions and educational bodies.",
+        theme_color: "#3880ff",
+        background_color: "#ffffff",
+        display: "standalone",
+        orientation: "portrait",
+        scope: "/",
+        start_url: "/",
+        icons: [
+          { src: "pwa-64x64.png", sizes: "64x64", type: "image/png" },
+          { src: "pwa-192x192.png", sizes: "192x192", type: "image/png" },
+          { src: "pwa-512x512.png", sizes: "512x512", type: "image/png", purpose: "any" },
+          { src: "maskable-icon-512x512.png", sizes: "512x512", type: "image/png", purpose: "maskable" },
+        ],
+      },
+      workbox: {
+        globPatterns: ["**/*.{js,css,html,ico,png,svg,woff2}"],
+        runtimeCaching: [
+          {
+            urlPattern: /^https:\/\/fonts\.googleapis\.com\/.*/i,
+            handler: "CacheFirst",
+            options: {
+              cacheName: "google-fonts-cache",
+              expiration: { maxEntries: 10, maxAgeSeconds: 60 * 60 * 24 * 365 },
+            },
+          },
+        ],
+      },
+    }),
   ],
 });


### PR DESCRIPTION
## Summary

- `public/manifest.json` had placeholder names (`My Ionic App` / `Ionic App`) left over from scaffolding. Updated to `Government Invoice & Billing System` / `GovtInvoice` and added `description`, `scope`, `orientation`, and `categories` fields required for a compliant PWA manifest.
- `vite.config.ts` had a bare `VitePWA({ registerType: "autoUpdate" })` call with no manifest configuration and no Workbox caching rules. Added the full manifest block (matching `manifest.json`) and Workbox `globPatterns` + `runtimeCaching` for Google Fonts.
- `src/app-data.ts` `APP_NAME` was set to `"Inventory Tracker for FVM Warehouse"` — a completely different product. Corrected to `"Government Invoice & Billing System"`.

All three values are now consistent so the app name is correct everywhere: the PWA install prompt, the email subject line, and the browser title.

## Test plan

- [ ] Build the app (`npm run build`) — no VitePWA config warnings
- [ ] Open DevTools → Application → Manifest — name and short_name are correct
- [ ] Install as PWA — install prompt shows "Government Invoice & Billing System"
- [ ] Email action uses correct app name in subject line

🤖 Generated with [Claude Code](https://claude.com/claude-code)