### PR TITLE
fix: move firebase init outside component to prevent loops

### DIFF
--- a/Govt-Billing-React/src/pages/Home.tsx
+++ b/Govt-Billing-React/src/pages/Home.tsx
@@ -23,6 +23,8 @@ import Files from "../components/Files/Files";
 import NewFile from "../components/NewFile/NewFile";
 import { initFirebase } from "../firebase/index";
 
+initFirebase();
+
 const Home: React.FC = () => {
   const [showMenu, setShowMenu] = useState(false);
   const [showPopover, setShowPopover] = useState<{
@@ -32,8 +34,6 @@ const Home: React.FC = () => {
   const [selectedFile, updateSelectedFile] = useState("default");
   const [billType, updateBillType] = useState(1);
   const [device] = useState("default");
-
-  initFirebase();
 
   const store = new Local();
 


### PR DESCRIPTION
- Closes #60 

### Description of Changes
- Moved the `initFirebase()` call from inside the `Home` functional component to the top-level module scope in `Govt-Billing-React/src/pages/Home.tsx`.
- This ensures the Firebase app is initialized exactly once when the application loads, rather than on every state update or re-render.

### Impact
- **Stability:** Prevents the `Firebase: Firebase App named '[DEFAULT]' already exists` error.
- **Performance:** Reduces unnecessary logic execution during the React component lifecycle.
- **Clean Code:** Adheres to React best practices for side-effects and global initializations.

### Testing Done
- Verified that the application initializes correctly on startup.
- Confirmed that UI interactions (menu toggles, file switching) no longer trigger re-initialization logic.