### PR TITLE
fix(firestore): add exists check to prevent crash on undefined docume…

### DIFF
--- a/Govt-Billing-React/src/firebase/firestore.ts
+++ b/Govt-Billing-React/src/firebase/firestore.ts
@@ -79,6 +79,9 @@ const downloadFileFromFirebase = async (userId, key, onSuccess) => {
     const local = new Local();
     const getFile = async () => {
       const docSnapshot = await getDoc(doc(db, "invoices", `${userId}-${key}`));
+      if (!docSnapshot.exists()) {
+        throw new Error("File not found on the server. It may have been deleted.");
+      }
       const data = docSnapshot.data();
       delete data["owner"];
       return data;


### PR DESCRIPTION
### 🔗 Related Issue
- Closes #62 

### Description of Changes
- Added a `!docSnapshot.exists()` validation check inside the `getFile` helper within `downloadFileFromFirebase`.
- If the document is missing, it now safely throws an explicit error instead of trying to manipulate an `undefined` object.

### Impact
- **Crash Prevention:** Prevents a fatal `TypeError: Cannot read properties of undefined` when a file is out of sync or missing.
- **Graceful Failure:** The error is now safely caught by the parent `catch` block, allowing the application to continue running smoothly.