### PR TITLE
fix(menu): add mailto fallback for web email support

### DIFF
--- a/Govt-Billing-React/src/components/Menu/Menu.tsx
+++ b/Govt-Billing-React/src/components/Menu/Menu.tsx
@@ -114,21 +114,35 @@ const Menu: React.FC<{
   };
 
   const sendEmail = () => {
+    const subject = `${APP_NAME} attached`;
+    const body = "Please find the attached spreadsheet.";
+  
     if (isPlatform("hybrid")) {
       const content = AppGeneral.getCurrentHTMLContent();
       const base64 = btoa(content);
-
+  
       EmailComposer.open({
         to: ["jackdwell08@gmail.com"],
         cc: [],
         bcc: [],
-        body: "PFA",
-        attachments: [{ type: "base64", path: base64, name: "Invoice.html" }],
-        subject: `${APP_NAME} attached`,
+        body,
+        attachments: [
+          {
+            type: "base64",
+            path: base64,
+            name: "Invoice.html",
+          },
+        ],
+        subject,
         isHtml: true,
       });
     } else {
-      alert("This Functionality works on Anroid/IOS devices");
+      // Web fallback: mailto doesn't support attachments, but opens user's email client
+      const mailtoLink = `mailto:?subject=${encodeURIComponent(
+        subject
+      )}&body=${encodeURIComponent(body)}`;
+  
+      window.location.href = mailtoLink;
     }
   };
 


### PR DESCRIPTION
Fix: #67 

## Summary

This PR adds a web fallback for the email sharing feature in `Menu.tsx`.

Previously, the app relied entirely on Capacitor's `EmailComposer`, which only works on Android/iOS hybrid platforms. Web users only received a generic alert message.

## Changes

- Added `mailto:` fallback support for web browsers
- Opens the user’s default email client on web
- Retained existing `EmailComposer` functionality for mobile devices
- Improved cross-platform user experience

## Screenshots

<img width="1134" height="780" alt="Screenshot 2026-05-12 at 10 11 38 AM" src="https://github.com/user-attachments/assets/2b4fe2ac-a6c0-4732-a512-c0ccf8d95621" />
 

## Result

| Platform | Behavior |
|---|---|
| Android/iOS | Opens Capacitor Email Composer |
| Web Browser | Opens default mail client using `mailto:` |