### PR TITLE
refactor(menu): remove hardcoded email recipient from EmailComposer

### DIFF
--- a/Govt-Billing-React/src/app-data.ts
+++ b/Govt-Billing-React/src/app-data.ts
@@ -1,4 +1,5 @@
 export let APP_NAME = "Inventory Tracker for FVM Warehouse";
+export let DEFAULT_EMAIL = "jackdwell08@gmail.com";
 
 export let DATA = {
   ledger: {

--- a/Govt-Billing-React/src/components/Menu/Menu.tsx
+++ b/Govt-Billing-React/src/components/Menu/Menu.tsx
@@ -6,7 +6,8 @@ import { EmailComposer } from "capacitor-email-composer";
 import { Printer } from "@ionic-native/printer";
 import { IonActionSheet, IonAlert } from "@ionic/react";
 import { saveOutline, save, mail, print } from "ionicons/icons";
-import { APP_NAME } from "../../app-data.js";
+import { APP_NAME, DEFAULT_EMAIL } from "../../app-data.js";
+import useUser from "../../hooks/useUser";
 
 const Menu: React.FC<{
   showM: boolean;
@@ -113,22 +114,33 @@ const Menu: React.FC<{
     }
   };
 
+  const { user } = useUser();
+  const recipientEmail = user?.email || DEFAULT_EMAIL;
+
   const sendEmail = () => {
+    const subject = `${APP_NAME} attached`;
+    const body = "Please find the attached spreadsheet.";
+
     if (isPlatform("hybrid")) {
       const content = AppGeneral.getCurrentHTMLContent();
       const base64 = btoa(content);
 
       EmailComposer.open({
-        to: ["jackdwell08@gmail.com"],
+        to: [recipientEmail],
         cc: [],
         bcc: [],
-        body: "PFA",
+        body,
         attachments: [{ type: "base64", path: base64, name: "Invoice.html" }],
-        subject: `${APP_NAME} attached`,
+        subject,
         isHtml: true,
       });
     } else {
-      alert("This Functionality works on Anroid/IOS devices");
+      // Web fallback using mailto:
+      const mailtoLink = `mailto:${recipientEmail}?subject=${encodeURIComponent(
+        subject
+      )}&body=${encodeURIComponent(body)}`;
+
+      window.location.href = mailtoLink;
     }
   };
 


### PR DESCRIPTION
Fix: #69 


## Summary

This PR removes the hardcoded recipient email address from the Email Composer implementation.

## Changes

- Removed hardcoded email recipient from `EmailComposer`
- Improved application flexibility and maintainability
- Prevented exposure of personal email addresses in source code

## Result

Users can now choose recipients directly from their email client instead of being forced to send emails to a predefined address.