### PR TITLE
fix(firestore): prevent double database write on file rename upload

### DIFF
--- a/Govt-Billing-React/src/firebase/firestore.ts
+++ b/Govt-Billing-React/src/firebase/firestore.ts
@@ -48,6 +48,8 @@ const uploadFileToCloud = async (
         ...fileData,
         owner: user.uid,
       });
+      if (onSuccess) onSuccess();
+      return;
     }
     await setDoc(doc(db, "invoices", `${user.uid}-${fileData.name}`), {
       ...fileData,


### PR DESCRIPTION
## Fix: Prevent Double-Write Quota Drain in Cloud Uploads

### Related Issue
- Closes #71 

### Description of Changes
- Fixed a control-flow bug in the `uploadFileToCloud` function (`firestore.ts`).
- When resolving a duplicate filename, the code previously saved the new file but fell through to execute a second `setDoc` operation.
- Added `if (onSuccess) onSuccess();` and a `return;` statement immediately after the conflict-resolution upload.

### Impact
- **Cost Optimization:** Cuts Firebase database writes in half when users resolve naming conflicts.
- **Network Stability:** Prevents concurrent duplicate POST requests to the backend.
- **Bug Prevention:** Stops the `onSuccess` callback from firing twice, which could cause erratic UI behavior.