### PR TITLE
fix(newfile): await local storage promise to prevent data corruption

### DIFF
--- a/Govt-Billing-React/src/components/NewFile/NewFile.tsx
+++ b/Govt-Billing-React/src/components/NewFile/NewFile.tsx
@@ -12,10 +12,10 @@ const NewFile: React.FC<{
   billType: number;
 }> = (props) => {
   const [showAlertNewFileCreated, setShowAlertNewFileCreated] = useState(false);
-  const newFile = () => {
+  const newFile = async () => {
     if (props.file !== "default") {
       const content = encodeURIComponent(AppGeneral.getSpreadsheetContent());
-      const data = props.store._getFile(props.file);
+      const data = await props.store._getFile(props.file);
       const file = new File(
         (data as any).created,
         new Date().toString(),


### PR DESCRIPTION
## Fix: Prevent Metadata Corruption on Auto-Save

### Related Issue
- Closes #73 

### Description of Changes
- In `NewFile.tsx`, the `newFile()` handler was executing a synchronous read on an asynchronous Local Storage API. 
- Converted `newFile()` to an `async` function.
- Added the `await` keyword to `props.store._getFile(props.file)` to properly resolve the file metadata before constructing the updated `File` object.

### Impact
- **Data Integrity:** Prevents the file's `created` timestamp from being overwritten with `undefined` when the user opens a new workspace.
- **Reliability:** Ensures that local storage operations complete sequentially, preventing race conditions between reading the old file and loading the default template.