### PR TITLE
feat(firestore): allow users to overwrite existing cloud files on upload

### DIFF
--- a/Govt-Billing-React/src/firebase/firestore.ts
+++ b/Govt-Billing-React/src/firebase/firestore.ts
@@ -30,24 +30,30 @@ const uploadFileToCloud = async (
       doc(db, "invoices", `${user.uid}-${fileData.name}`)
     );
     if (prevFile.exists()) {
-      alert("File With the same name exists");
-      const newName = prompt("Enter New Name for File");
-      if (!newName) {
-        alert("Name Cannot be empty");
-        return;
-      }
-      const prevFile = await getDoc(
-        doc(db, "invoices", `${user.uid}-${newName}`)
+      const shouldOverwrite = confirm(
+        "A file with this name already exists in the cloud. Do you want to overwrite it with your current changes?"
       );
-      if (prevFile.exists()) {
-        alert("File With the same name exists");
+      if (!shouldOverwrite) {
+        const newName = prompt("Enter a new name to save as a copy:");
+        if (!newName) {
+          alert("Upload cancelled.");
+          return;
+        }
+        const prevNewFile = await getDoc(
+          doc(db, "invoices", `${user.uid}-${newName}`)
+        );
+        if (prevNewFile.exists()) {
+          alert("A file with this name also exists. Upload cancelled.");
+          return;
+        }
+        fileData.name = newName;
+        await setDoc(doc(db, "invoices", `${user.uid}-${newName}`), {
+          ...fileData,
+          owner: user.uid,
+        });
+        if (onSuccess) onSuccess();
         return;
       }
-      fileData.name = newName;
-      await setDoc(doc(db, "invoices", `${user.uid}-${newName}`), {
-        ...fileData,
-        owner: user.uid,
-      });
     }
     await setDoc(doc(db, "invoices", `${user.uid}-${fileData.name}`), {
       ...fileData,


### PR DESCRIPTION
## Fix: Enable Cloud File Overwrites / Updates

### Related Issue
- Closes #75

### Description of Changes
- Refactored the `uploadFileToCloud` function in `firestore.ts`.
- Previously, the app forced a rename operation if a file already existed in the cloud, removing the ability to "update" or "sync" existing invoices.
- Implemented a `confirm()` dialog. If the user chooses to overwrite, the code seamlessly updates the existing document. If they decline, it prompts them to save as a new copy.

### Impact
- **Core Functionality Restored:** Users can now actually save changes to their existing cloud invoices without generating duplicates.
- **Improved UX:** Replaced the jarring `alert()` with a clear, standard "Do you want to overwrite?" workflow.
- **Cleaner Database:** Prevents users from cluttering their Firebase storage with unnecessary versioned files (`invoice_1`, `invoice_2`, etc.).