### PR TITLE
fix(files): prevent fatal TypeError crash on unauthenticated cloud ac…

### DIFF
--- a/Govt-Billing-React/src/components/Files/Files.tsx
+++ b/Govt-Billing-React/src/components/Files/Files.tsx
@@ -86,6 +86,8 @@ const Files: React.FC<{
       if (isLoading) return;
       if (!user) {
         alert("Login to Continue");
+        setListFiles(false);
+        return;
       } else {
         files = await getFilesKeysFromFirestore(user.uid);
       }


### PR DESCRIPTION
## Fix: Prevent Fatal App Crash on Unauthenticated Cloud Access

### Related Issue
- Closes #78 

### Description of Changes
- Fixed a critical oversight in the `temp()` function inside `Files.tsx`.
- Previously, if a user who wasn't logged in clicked the Cloud files icon, the app would alert them but continue executing the function. This resulted in `Object.keys(undefined)`, throwing a fatal `TypeError` that crashed the entire React DOM.
- Added `setListFiles(false)` and a `return;` statement inside the `!user` condition block.

### Impact
- **Crash Prevention:** The app no longer "White Screens" when an unauthenticated user tries to interact with cloud features.
- **Data Safety:** Prevents users from losing unsaved spreadsheet data due to an unexpected UI crash.
- **Graceful Failure:** The operation is now safely aborted, and the modal state is reset properly.