### PR TITLE
fix(files): prevent unrelated file deletions from wiping the active w…

### DIFF
--- a/Govt-Billing-React/src/components/Files/Files.tsx
+++ b/Govt-Billing-React/src/components/Files/Files.tsx
@@ -183,12 +183,16 @@ const Files: React.FC<{
             handler: () => {
               if (props.filesFrom === "Local") {
                 props.store._deleteFile(currentKey);
-                loadDefault();
+                if (currentKey === props.file) {
+                  loadDefault();
+                }
                 setCurrentKey(null);
               } else {
                 deleteFileFromFirebase(user.uid, currentKey, () => {
                   setListFiles(false);
-                  loadDefault();
+                  if (currentKey === props.file) {
+                    loadDefault();
+                  }
                   setCurrentKey(null);
                 });
               }


### PR DESCRIPTION
## Fix: Prevent Unsaved Data Loss During File Management

### Related Issue
- Closes #80 

### Description of Changes
- Modified the deletion handler within the `IonAlert` in `Files.tsx`.
- Previously, deleting *any* file triggered `loadDefault()`, which erased the active spreadsheet.
- Added a conditional wrapper `if (currentKey === props.file)` around the `loadDefault()` function.

### Impact
- **Data Protection:** Users can now safely delete old or unwanted files from their file manager while actively working on a different invoice without fear of their current screen being wiped.
- **Workflow Integrity:** The workspace now correctly persists unless the user specifically deletes the exact file they are currently viewing.