### PR TITLE
Fix async save flow handling in React app

### DIFF
--- a/Govt-Billing-React/src/components/Menu/Menu.tsx
+++ b/Govt-Billing-React/src/components/Menu/Menu.tsx
@@ -68,15 +68,22 @@ const Menu: React.FC<{
       printWindow.print();
     }
   };
-  const doSave = () => {
+  const doSave = async () => {
     if (props.file === "default") {
       setShowAlert1(true);
       return;
     }
     const content = encodeURIComponent(AppGeneral.getSpreadsheetContent());
-    const data = props.store._getFile(props.file);
+    const data = await props.store._getFile(props.file);
+
+    if (!data) {
+      setToastMessage("Save failed: file data could not be retrieved.");
+      setShowToast1(true);
+      return;
+    }
+
     const file = new File(
-      (data as any).created,
+      data.created,
       new Date().toString(),
       content,
       props.file,

--- a/Govt-Billing-React/src/components/NewFile/NewFile.tsx
+++ b/Govt-Billing-React/src/components/NewFile/NewFile.tsx
@@ -2,7 +2,7 @@ import React, { useState } from "react";
 import * as AppGeneral from "../socialcalc/index.js";
 import { File, Local } from "../Storage/LocalStorage";
 import { DATA } from "../../app-data.js";
-import { IonAlert, IonIcon } from "@ionic/react";
+import { IonAlert, IonIcon, IonToast } from "@ionic/react";
 import { add } from "ionicons/icons";
 
 const NewFile: React.FC<{
@@ -12,12 +12,22 @@ const NewFile: React.FC<{
   billType: number;
 }> = (props) => {
   const [showAlertNewFileCreated, setShowAlertNewFileCreated] = useState(false);
-  const newFile = () => {
+  const [showToast, setShowToast] = useState(false);
+  const [toastMessage, setToastMessage] = useState("");
+
+  const newFile = async () => {
     if (props.file !== "default") {
       const content = encodeURIComponent(AppGeneral.getSpreadsheetContent());
-      const data = props.store._getFile(props.file);
+      const data = await props.store._getFile(props.file);
+
+      if (!data) {
+        setToastMessage("Could not persist current file before reset.");
+        setShowToast(true);
+        return;
+      }
+
       const file = new File(
-        (data as any).created,
+        data.created,
         new Date().toString(),
         content,
         props.file,
@@ -51,6 +61,14 @@ const NewFile: React.FC<{
         header="Alert Message"
         message={"New file created!"}
         buttons={["Ok"]}
+      />
+      <IonToast
+        animated
+        isOpen={showToast}
+        onDidDismiss={() => setShowToast(false)}
+        position="bottom"
+        message={toastMessage}
+        duration={1500}
       />
     </React.Fragment>
   );


### PR DESCRIPTION
## What's wrong

`doSave()` and `newFile()` call `_getFile()` without `await`, so they 
get a Promise instead of actual file data. This means `data.created` 
is always `undefined` — silently corrupting metadata on every save.

## What I changed

- `doSave()` in Menu.tsx → made async, added await + null guard with IonToast
- `newFile()` in NewFile.tsx → same fix

## Proof

Validated in browser console (screenshot below) — BEFORE shows 
`undefined`, AFTER shows the correct date, GUARD confirms no crash 
on missing file.

Closes #38


<img width="664" height="202" alt="Screenshot 2026-05-15 151013" src="https://github.com/user-attachments/assets/cb955d00-6449-44e4-851f-d36ceeb0b5ef" />
