### PR TITLE
Fix incorrect Save As reopen after toast dismiss

### DIFF
--- a/Govt-Billing-React/src/components/Menu/Menu.tsx
+++ b/Govt-Billing-React/src/components/Menu/Menu.tsx
@@ -22,6 +22,7 @@ const Menu: React.FC<{
   const [showAlert4, setShowAlert4] = useState(false);
   const [showToast1, setShowToast1] = useState(false);
   const [toastMessage, setToastMessage] = useState("");
+  const [toastFromSaveAs, setToastFromSaveAs] = useState(false);
   /* Utility functions */
   const _validateName = async (filename) => {
     filename = filename.trim();
@@ -68,15 +69,23 @@ const Menu: React.FC<{
       printWindow.print();
     }
   };
-  const doSave = () => {
+  const doSave = async () => {
     if (props.file === "default") {
       setShowAlert1(true);
       return;
     }
     const content = encodeURIComponent(AppGeneral.getSpreadsheetContent());
-    const data = props.store._getFile(props.file);
+    const data = await props.store._getFile(props.file);
+
+    if (!data) {
+      setToastFromSaveAs(false);
+      setToastMessage("Save failed: file data could not be retrieved.");
+      setShowToast1(true);
+      return;
+    }
+
     const file = new File(
-      (data as any).created,
+      data.created,
       new Date().toString(),
       content,
       props.file,
@@ -108,6 +117,7 @@ const Menu: React.FC<{
         props.updateSelectedFile(filename);
         setShowAlert4(true);
       } else {
+        setToastFromSaveAs(true);
         setShowToast1(true);
       }
     }
@@ -230,7 +240,9 @@ const Menu: React.FC<{
         isOpen={showToast1}
         onDidDismiss={() => {
           setShowToast1(false);
-          setShowAlert3(true);
+          if (toastFromSaveAs) {
+            setShowAlert3(true);
+          }
         }}
         position="bottom"
         message={toastMessage}


### PR DESCRIPTION
## Changes

* Added flow-aware toast handling in `Menu.tsx`
* Prevented Save As dialog from reopening after unrelated save failures
* Preserved existing Save As validation behavior
* Added conditional reopen logic based on the originating toast flow

## Testing

* Verified Save As validation flow still reopens correctly
* Verified save failure flow no longer reopens Save As dialog
* Confirmed toast dismiss behavior works correctly in both scenarios

## Proof

Attached console/UI validation screenshots demonstrating:

* Save failure toast no longer reopens Save As
* Save As validation flow still behaves correctly
<img width="618" height="158" alt="image" src="https://github.com/user-attachments/assets/2ea0668b-2758-46ef-9b8a-4ce64fd14285" />


## Issue

Fixes #86
