### PR TITLE
feat: add CSV invoice export

### DIFF
--- a/Govt-Billing-React/package-lock.json
+++ b/Govt-Billing-React/package-lock.json
@@ -11,6 +11,7 @@
         "@capacitor/android": "5.7.0",
         "@capacitor/app": "5.0.7",
         "@capacitor/core": "5.7.0",
+        "@capacitor/filesystem": "^5.2.2",
         "@capacitor/haptics": "5.0.7",
         "@capacitor/ios": "5.7.0",
         "@capacitor/keyboard": "5.0.8",
@@ -2086,6 +2087,15 @@
       "integrity": "sha512-wa9Fao+Axa1t2ZERMyQD9r0xyfglQyC4DHQKintzKaIqcRuVe9J31TmfD3IxROYi9LGpY4X8cq4m4bjb0W94Qg==",
       "dependencies": {
         "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/@capacitor/filesystem": {
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/@capacitor/filesystem/-/filesystem-5.2.2.tgz",
+      "integrity": "sha512-h0Ta0NXF/zX9bXoD5qtoEoWSWCewow8Kredb2bBFO+vrd4NVthZH+GyrII2dk0++UIw40HjyLNk4apwGGSu9Sg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@capacitor/core": "^5.1.1"
       }
     },
     "node_modules/@capacitor/haptics": {

--- a/Govt-Billing-React/package.json
+++ b/Govt-Billing-React/package.json
@@ -16,6 +16,7 @@
     "@capacitor/android": "5.7.0",
     "@capacitor/app": "5.0.7",
     "@capacitor/core": "5.7.0",
+    "@capacitor/filesystem": "^5.2.2",
     "@capacitor/haptics": "5.0.7",
     "@capacitor/ios": "5.7.0",
     "@capacitor/keyboard": "5.0.8",

--- a/Govt-Billing-React/src/components/Menu/Menu.tsx
+++ b/Govt-Billing-React/src/components/Menu/Menu.tsx
@@ -5,8 +5,10 @@ import { isPlatform, IonToast } from "@ionic/react";
 import { EmailComposer } from "capacitor-email-composer";
 import { Printer } from "@ionic-native/printer";
 import { IonActionSheet, IonAlert } from "@ionic/react";
-import { saveOutline, save, mail, print } from "ionicons/icons";
+import { saveOutline, save, mail, print, download } from "ionicons/icons";
+import { Directory, Encoding, Filesystem } from "@capacitor/filesystem";
 import { APP_NAME } from "../../app-data.js";
+import { convertSpreadsheetToCSV } from "../../services/csvExportService";
 
 const Menu: React.FC<{
   showM: boolean;
@@ -113,6 +115,47 @@ const Menu: React.FC<{
     }
   };
 
+  const doExportCSV = async () => {
+    const rawContent = AppGeneral.getSpreadsheetContent();
+    const invoiceName = props.file === "default" ? "invoice" : props.file;
+    const { csv, filename } = convertSpreadsheetToCSV(rawContent, invoiceName);
+
+    if (!csv.trim()) {
+      setToastMessage("Nothing to export");
+      setShowToast1(true);
+      return;
+    }
+
+    if (isPlatform("hybrid")) {
+      try {
+        await Filesystem.writeFile({
+          path: filename,
+          data: csv,
+          directory: Directory.Documents,
+          encoding: Encoding.UTF8,
+        });
+        setToastMessage(`CSV saved: ${filename}`);
+      } catch (err: any) {
+        setToastMessage(`Export failed: ${err?.message ?? "Unknown error"}`);
+      }
+      setShowToast1(true);
+      return;
+    }
+
+    const blob = new Blob([csv], { type: "text/csv;charset=utf-8;" });
+    const url = URL.createObjectURL(blob);
+    const link = document.createElement("a");
+    link.href = url;
+    link.download = filename;
+    document.body.appendChild(link);
+    link.click();
+    document.body.removeChild(link);
+    URL.revokeObjectURL(url);
+
+    setToastMessage(`CSV exported: ${filename}`);
+    setShowToast1(true);
+  };
+
   const sendEmail = () => {
     if (isPlatform("hybrid")) {
       const content = AppGeneral.getCurrentHTMLContent();
@@ -154,6 +197,14 @@ const Menu: React.FC<{
             handler: () => {
               setShowAlert3(true);
               console.log("Save As clicked");
+            },
+          },
+          {
+            text: "Export as CSV",
+            icon: download,
+            handler: () => {
+              doExportCSV();
+              console.log("Export CSV clicked");
             },
           },
           {
@@ -230,11 +281,18 @@ const Menu: React.FC<{
         isOpen={showToast1}
         onDidDismiss={() => {
           setShowToast1(false);
-          setShowAlert3(true);
+          if (
+            toastMessage !== "" &&
+            !toastMessage.startsWith("CSV") &&
+            !toastMessage.startsWith("Export") &&
+            !toastMessage.startsWith("Nothing")
+          ) {
+            setShowAlert3(true);
+          }
         }}
         position="bottom"
         message={toastMessage}
-        duration={500}
+        duration={1500}
       />
     </React.Fragment>
   );

--- a/Govt-Billing-React/src/services/csvExportService.ts
+++ b/Govt-Billing-React/src/services/csvExportService.ts
@@ -1,0 +1,91 @@
+export interface CsvExportResult {
+  csv: string;
+  filename: string;
+}
+
+type CellRef = {
+  col: number;
+  row: number;
+};
+
+const decodeSocialCalcValue = (value: string): string =>
+  value.replace(/\\c/g, ":").replace(/\\n/g, "\n").replace(/\\b/g, "\\");
+
+const colLetterToIndex = (col: string): number => {
+  let index = 0;
+  for (let i = 0; i < col.length; i++) {
+    index = index * 26 + (col.charCodeAt(i) - 64);
+  }
+  return index;
+};
+
+const parseCellRef = (ref: string): CellRef | null => {
+  const match = ref.match(/^([A-Z]+)(\d+)$/);
+  if (!match) return null;
+  return { col: colLetterToIndex(match[1]), row: parseInt(match[2], 10) };
+};
+
+const getCellValue = (parts: string[]): string => {
+  const type = parts[2];
+
+  if (type === "v" || type === "t") {
+    return decodeSocialCalcValue(parts[3] ?? "");
+  }
+
+  if (type === "vt" || type === "vtf" || type === "vtc") {
+    return decodeSocialCalcValue(parts[4] ?? "");
+  }
+
+  return "";
+};
+
+const escapeCsvCell = (cell: string): string => {
+  const escaped = cell.replace(/"/g, '""');
+  return /[",\n\r]/.test(escaped) ? `"${escaped}"` : escaped;
+};
+
+export function convertSpreadsheetToCSV(
+  spreadsheetContent: string,
+  invoiceName: string
+): CsvExportResult {
+  const grid: Record<number, Record<number, string>> = {};
+  let maxRow = 0;
+  let maxCol = 0;
+
+  spreadsheetContent.split("\n").forEach((line) => {
+    if (!line.startsWith("cell:")) return;
+
+    const parts = line.split(":");
+    if (parts.length < 4) return;
+
+    const ref = parseCellRef(parts[1]);
+    if (!ref) return;
+
+    const value = getCellValue(parts);
+    if (!grid[ref.row]) grid[ref.row] = {};
+    grid[ref.row][ref.col] = value;
+
+    maxRow = Math.max(maxRow, ref.row);
+    maxCol = Math.max(maxCol, ref.col);
+  });
+
+  const csvRows: string[] = [];
+  for (let row = 1; row <= maxRow; row++) {
+    const rowCells: string[] = [];
+    for (let col = 1; col <= maxCol; col++) {
+      rowCells.push(escapeCsvCell(grid[row]?.[col] ?? ""));
+    }
+
+    if (rowCells.some((cell) => cell !== "")) {
+      csvRows.push(rowCells.join(","));
+    }
+  }
+
+  const safeName = invoiceName.replace(/[^a-zA-Z0-9-_]/g, "_") || "invoice";
+  const filename = `${safeName}_${new Date().toISOString().slice(0, 10)}.csv`;
+
+  return {
+    csv: csvRows.join("\n"),
+    filename,
+  };
+}


### PR DESCRIPTION
## Summary

Adds CSV export support for invoices using `@capacitor/filesystem`.

This PR introduces a CSV export flow for the current SocialCalc invoice by parsing the serialized spreadsheet format and exporting it as a properly escaped CSV file for both PWA and hybrid/mobile environments.

## Changes

### Added

* `src/services/csvExportService.ts`

  * Parses SocialCalc serialized spreadsheet content
  * Supports escaped values (`\c`, `\n`, `\b`)
  * Handles formula/result cell types (`vt`, `vtf`, `vtc`)
  * Generates properly escaped CSV rows and filenames

### Updated

* `src/components/Menu/Menu.tsx`

  * Added **Export as CSV** option to the existing ActionSheet
  * Added native/hybrid export support using `@capacitor/filesystem`
  * Added browser/PWA CSV download fallback
  * Updated toast dismissal handling to avoid reopening the Save As dialog after CSV export actions

* `package.json`

  * Added `@capacitor/filesystem`

* `package-lock.json`

  * Updated dependency lockfile

## Acceptance Criteria Addressed

* ✅ Invoices can be exported as CSV
* ✅ Adds Capacitor plugin integration
* ✅ Works across PWA and hybrid/mobile flows
* ✅ Maintains existing Save / Save As behavior

## Validation

Verified locally by:

* testing CSV generation from SocialCalc invoice data
* validating escaped commas, quotes, colons, and newline handling
* validating formula/result cell parsing
* running:

```bash id="u7lt3f"
npm run build
```

Build completed successfully.

## Screenshot

The screenshot below demonstrates successful CSV generation from serialized SocialCalc invoice data, including:

* parsed invoice rows
* formula result handling
* escaped special characters
* generated CSV filename output

<img width="1093" height="338" alt="Screenshot 2026-05-21 141156" src="https://github.com/user-attachments/assets/520dc388-eb06-46b1-a56b-18a1227b195b" />

