### PR TITLE
feat: add Invoice PDF export with print and HTML download

### DIFF
--- a/Govt-Billing-React/src/components/InvoicePDF/InvoicePDFModal.tsx
+++ b/Govt-Billing-React/src/components/InvoicePDF/InvoicePDFModal.tsx
@@ -1,0 +1,142 @@
+import React, { useState } from "react";
+import {
+  IonModal,
+  IonHeader,
+  IonToolbar,
+  IonTitle,
+  IonContent,
+  IonButton,
+  IonIcon,
+  IonItem,
+  IonLabel,
+  IonList,
+  IonToast,
+  IonButtons,
+  IonText,
+} from "@ionic/react";
+import {
+  documentOutline,
+  downloadOutline,
+  printOutline,
+  closeOutline,
+  checkmarkCircleOutline,
+} from "ionicons/icons";
+import { useInvoicePDF } from "../../hooks/useInvoicePDF";
+
+interface InvoicePDFModalProps {
+  show: boolean;
+  setShow: (val: boolean) => void;
+  filename: string;
+}
+
+const InvoicePDFModal: React.FC<InvoicePDFModalProps> = ({
+  show,
+  setShow,
+  filename,
+}) => {
+  const { exportAsPDF, downloadHTML } = useInvoicePDF();
+  const [toastMessage, setToastMessage] = useState("");
+  const [showToast, setShowToast] = useState(false);
+
+  const handleExportPDF = () => {
+    // iframe-based print — no popup blocker issues, no try/catch needed
+    exportAsPDF(filename);
+    setToastMessage("Print dialog opening — choose 'Save as PDF' as destination.");
+    setShowToast(true);
+    setShow(false);
+  };
+
+  const handleDownloadHTML = () => {
+    try {
+      downloadHTML(filename);
+      setToastMessage("Invoice downloaded as HTML file.");
+      setShowToast(true);
+      setShow(false);
+    } catch {
+      setToastMessage("Download failed. Please try again.");
+      setShowToast(true);
+    }
+  };
+
+  return (
+    <>
+      <IonModal isOpen={show} onDidDismiss={() => setShow(false)}>
+        <IonHeader>
+          <IonToolbar color="primary">
+            <IonTitle>Export Invoice as PDF</IonTitle>
+            <IonButtons slot="end">
+              <IonButton onClick={() => setShow(false)}>
+                <IonIcon icon={closeOutline} />
+              </IonButton>
+            </IonButtons>
+          </IonToolbar>
+        </IonHeader>
+
+        <IonContent className="ion-padding">
+          <IonItem lines="none" className="ion-margin-bottom">
+            <IonIcon icon={documentOutline} slot="start" color="primary" />
+            <IonLabel>
+              <h2>Current Invoice</h2>
+              <p>{filename}</p>
+            </IonLabel>
+          </IonItem>
+
+          <IonText color="medium">
+            <p className="ion-padding-horizontal ion-padding-bottom">
+              Choose how you want to export this invoice. Both options include a
+              formatted header with the invoice name and export timestamp.
+            </p>
+          </IonText>
+
+          <IonList inset>
+            <IonItem button detail onClick={handleExportPDF} lines="full">
+              <IonIcon icon={printOutline} slot="start" color="primary" />
+              <IonLabel>
+                <h2>Export as PDF</h2>
+                <p>Opens print dialog — set destination to "Save as PDF"</p>
+              </IonLabel>
+            </IonItem>
+
+            <IonItem button detail onClick={handleDownloadHTML} lines="none">
+              <IonIcon icon={downloadOutline} slot="start" color="secondary" />
+              <IonLabel>
+                <h2>Download as HTML</h2>
+                <p>Self-contained file — open in any browser or email as attachment</p>
+              </IonLabel>
+            </IonItem>
+          </IonList>
+
+          <IonItem lines="none" className="ion-margin-top">
+            <IonIcon icon={checkmarkCircleOutline} slot="start" color="success" />
+            <IonLabel className="ion-text-wrap">
+              <p>
+                <strong>Tip:</strong> In the print dialog, set "Destination" to
+                "Save as PDF" and disable headers/footers for the cleanest output.
+              </p>
+            </IonLabel>
+          </IonItem>
+
+          <IonButton
+            expand="block"
+            fill="outline"
+            color="medium"
+            className="ion-margin-top"
+            onClick={() => setShow(false)}
+          >
+            Cancel
+          </IonButton>
+        </IonContent>
+      </IonModal>
+
+      <IonToast
+        isOpen={showToast}
+        onDidDismiss={() => setShowToast(false)}
+        message={toastMessage}
+        duration={3000}
+        position="bottom"
+      />
+    </>
+  );
+};
+
+export default InvoicePDFModal;

--- a/Govt-Billing-React/src/components/Menu/Menu.tsx
+++ b/Govt-Billing-React/src/components/Menu/Menu.tsx
@@ -5,8 +5,9 @@ import { isPlatform, IonToast } from "@ionic/react";
 import { EmailComposer } from "capacitor-email-composer";
 import { Printer } from "@ionic-native/printer";
 import { IonActionSheet, IonAlert } from "@ionic/react";
-import { saveOutline, save, mail, print } from "ionicons/icons";
+import { saveOutline, save, mail, print, documentText } from "ionicons/icons";
 import { APP_NAME } from "../../app-data.js";
+import InvoicePDFModal from "../InvoicePDF/InvoicePDFModal";
 
 const Menu: React.FC<{
   showM: boolean;
@@ -16,6 +17,7 @@ const Menu: React.FC<{
   store: Local;
   bT: number;
 }> = (props) => {
+  const [showPDFModal, setShowPDFModal] = useState(false);
   const [showAlert1, setShowAlert1] = useState(false);
   const [showAlert2, setShowAlert2] = useState(false);
   const [showAlert3, setShowAlert3] = useState(false);
@@ -157,6 +159,14 @@ const Menu: React.FC<{
             },
           },
           {
+            text: "Export as PDF",
+            icon: documentText,
+            handler: () => {
+              setShowPDFModal(true);
+              console.log("Export PDF clicked");
+            },
+          },
+          {
             text: "Print",
             icon: print,
             handler: () => {
@@ -235,6 +245,11 @@ const Menu: React.FC<{
         position="bottom"
         message={toastMessage}
         duration={500}
+      />
+      <InvoicePDFModal
+        show={showPDFModal}
+        setShow={setShowPDFModal}
+        filename={props.file}
       />
     </React.Fragment>
   );

--- a/Govt-Billing-React/src/hooks/useInvoicePDF.ts
+++ b/Govt-Billing-React/src/hooks/useInvoicePDF.ts
@@ -1,0 +1,143 @@
+import { APP_NAME } from "../app-data";
+import * as AppGeneral from "../components/socialcalc/index.js";
+
+/**
+ * Takes the raw HTML string from SocialCalc and replaces any <canvas ...></canvas>
+ * elements with a placeholder note. No DOM mutation — pure string processing.
+ *
+ * Why: canvas pixel data can't survive HTML serialisation. Rather than
+ * attempting risky DOM swaps (which cause NotFoundError when React re-renders
+ * during the swap), we cleanly remove canvases and note their absence.
+ */
+const replaceCanvasesInHTML = (html: string): string => {
+  // Match <canvas ...>...</canvas> — covers both self-closing and paired tags
+  return html.replace(
+    /<canvas[^>]*>[\s\S]*?<\/canvas>/gi,
+    '<p style="color:#888;font-size:10px;font-style:italic;margin:4px 0;">[Chart — view in app]</p>'
+  );
+};
+
+const buildPDFHTML = (filename: string): string => {
+  const rawHTML = AppGeneral.getCurrentHTMLContent();
+  const sheetHTML = replaceCanvasesInHTML(rawHTML);
+  const exportedAt = new Date().toLocaleString();
+
+  return `<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <title>${APP_NAME} — ${filename}</title>
+  <style>
+    *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+    body {
+      font-family: 'Segoe UI', Arial, sans-serif;
+      font-size: 12px;
+      color: #1a1a2e;
+      background: #fff;
+      padding: 32px 40px;
+    }
+    .pdf-header {
+      display: flex;
+      justify-content: space-between;
+      align-items: flex-start;
+      border-bottom: 3px solid #3880ff;
+      padding-bottom: 16px;
+      margin-bottom: 24px;
+    }
+    .pdf-header .org-block h1 { font-size: 22px; font-weight: 700; color: #3880ff; }
+    .pdf-header .org-block p  { font-size: 11px; color: #555; margin-top: 2px; }
+    .pdf-header .meta-block   { text-align: right; font-size: 11px; color: #444; line-height: 1.8; }
+    .pdf-header .meta-block .invoice-label {
+      font-size: 18px; font-weight: 700; color: #3880ff; display: block; margin-bottom: 4px;
+    }
+    .sheet-wrapper { overflow-x: auto; }
+    .sheet-wrapper table { width: 100%; border-collapse: collapse; font-size: 11px; }
+    .sheet-wrapper td, .sheet-wrapper th {
+      border: 1px solid #d0d8e8; padding: 5px 8px; vertical-align: top;
+    }
+    .sheet-wrapper tr:nth-child(even) td { background: #f5f8ff; }
+    .sheet-wrapper img { max-width: 100%; height: auto; display: block; margin: 8px 0; }
+    .pdf-footer {
+      margin-top: 28px; border-top: 1px solid #d0d8e8; padding-top: 12px;
+      display: flex; justify-content: space-between; font-size: 10px; color: #888;
+    }
+    @media print {
+      body { padding: 16px; }
+      .sheet-wrapper { overflow: visible; }
+      @page { margin: 1cm; size: A4; }
+    }
+  </style>
+</head>
+<body>
+  <div class="pdf-header">
+    <div class="org-block">
+      <h1>${APP_NAME}</h1>
+      <p>Government Billing &amp; Invoicing System</p>
+    </div>
+    <div class="meta-block">
+      <span class="invoice-label">INVOICE</span>
+      <span><strong>File:</strong> ${filename}</span>
+      <span><strong>Exported:</strong> ${exportedAt}</span>
+    </div>
+  </div>
+  <div class="sheet-wrapper">${sheetHTML}</div>
+  <div class="pdf-footer">
+    <span>${APP_NAME} — Official Document</span>
+    <span>Generated on ${exportedAt}</span>
+  </div>
+</body>
+</html>`;
+};
+
+/**
+ * Prints via a hidden iframe — avoids window.open popup blocker entirely.
+ */
+const printViaIframe = (html: string): void => {
+  const existing = document.getElementById("__invoice_print_frame__");
+  if (existing) existing.remove();
+
+  const iframe = document.createElement("iframe");
+  iframe.id = "__invoice_print_frame__";
+  iframe.style.cssText =
+    "position:fixed;top:0;left:0;width:0;height:0;border:none;opacity:0;pointer-events:none;";
+
+  document.body.appendChild(iframe);
+
+  const iframeDoc = iframe.contentDocument || iframe.contentWindow?.document;
+  if (!iframeDoc) {
+    iframe.remove();
+    throw new Error("Could not access iframe document");
+  }
+
+  iframeDoc.open();
+  iframeDoc.write(html);
+  iframeDoc.close();
+
+  iframe.onload = () => {
+    iframe.contentWindow?.focus();
+    iframe.contentWindow?.print();
+    setTimeout(() => iframe.remove(), 2000);
+  };
+};
+
+export const useInvoicePDF = () => {
+  const exportAsPDF = (filename: string = "Invoice"): void => {
+    const html = buildPDFHTML(filename);
+    printViaIframe(html);
+  };
+
+  const downloadHTML = (filename: string = "Invoice"): void => {
+    const html = buildPDFHTML(filename);
+    const blob = new Blob([html], { type: "text/html;charset=utf-8" });
+    const url = URL.createObjectURL(blob);
+    const anchor = document.createElement("a");
+    anchor.href = url;
+    anchor.download = `${filename.replace(/\s+/g, "_")}_invoice.html`;
+    document.body.appendChild(anchor);
+    anchor.click();
+    document.body.removeChild(anchor);
+    URL.revokeObjectURL(url);
+  };
+
+  return { exportAsPDF, downloadHTML };
+};


### PR DESCRIPTION
<html><head></head><body><h2>Summary</h2>
<p>Closes #94</p>
<p>Adds a self-contained Invoice PDF export feature to GovtInvoice.
Users can export the current spreadsheet invoice as a styled,
print-ready PDF or download it as a standalone HTML file —
both with zero extra dependencies.</p>
<h2>What Changed</h2>
<h3>New files</h3>

File | Purpose
-- | --
Govt-Billing-React/src/hooks/useInvoicePDF.ts | Core hook — exportAsPDF() and downloadHTML()
Govt-Billing-React/src/components/InvoicePDF/InvoicePDFModal.tsx | IonModal UI for choosing export format


<h2>How It Works</h2>
<pre><code>FAB menu → "Export as PDF"
  └── InvoicePDFModal opens
        ├── "Export as PDF"    → printViaIframe()
        │     └── Hidden iframe injected into page
        │           └── iframe.contentWindow.print() fires
        │                 └── User selects "Save as PDF"
        └── "Download as HTML" → Blob + &lt;a download&gt; → .html file
</code></pre>
<h3>Key implementation decisions</h3>
<ul>
<li><strong>Hidden iframe</strong> instead of <code>window.open</code> — avoids popup blockers
entirely, works on localhost and Capacitor WebView</li>
<li><strong>No DOM mutation</strong> for canvas handling — canvas elements are
replaced with <code>[Chart — view in app]</code> via regex on the HTML string,
avoiding React re-render conflicts (<code>insertBefore</code> NotFoundError)</li>
<li><strong>Zero new dependencies</strong> — uses only browser-native APIs
(<code>Blob</code>, <code>URL.createObjectURL</code>, <code>iframe.contentWindow.print()</code>)</li>
</ul>
<h2>UI Flow</h2>
<ol>
<li>Tap the FAB button (☰) at bottom right</li>
<li>Action sheet opens → tap <strong>"Export as PDF"</strong></li>
<li><code>InvoicePDFModal</code> opens showing:
<ul>
<li>Current invoice filename</li>
<li>Two export options with descriptions</li>
<li>Tip about "Save as PDF" in print dialog</li>
</ul>
</li>
<li>Choose an option → toast confirms action → modal closes</li>
</ol>
<h2>Screenshots</h2>
<img width="619" height="601" alt="image" src="https://github.com/user-attachments/assets/f3050101-3fa4-4ebe-9355-f52757c5a3d7" />
<img width="1282" height="874" alt="image" src="https://github.com/user-attachments/assets/19ddde5f-aa29-42be-8773-e403a9bec5f8" />
<img width="403" height="194" alt="image" src="https://github.com/user-attachments/assets/1a8808c2-a20d-46f1-bf0a-6c6a5daed7ed" />

<h2>Testing Checklist</h2>
<ul>
<li>[x] Export as PDF — print dialog opens via hidden iframe</li>
<li>[x] Download as HTML — <code>.html</code> file downloads with correct filename</li>
<li>[x] Modal opens and closes correctly</li>
<li>[x] Toast confirmation shows after each action</li>
<li>[x] Works on Chrome (desktop)</li>
<li>[x] Works on Firefox (desktop)</li>
<li>[ ] Android Capacitor</li>
<li>[ ] iOS Capacitor</li>
</ul>
<h2>No New Dependencies</h2>
<p>Uses only browser-native APIs — no <code>jsPDF</code>, <code>html2canvas</code>, or any
other package added. <code>package.json</code> is unchanged.</p></body></html>